### PR TITLE
Fix version

### DIFF
--- a/lib4vex/version.py
+++ b/lib4vex/version.py
@@ -1,4 +1,4 @@
 # Copyright (C) 2026 Anthony Harrison
 # SPDX-License-Identifier: Apache-2.0
 
-VERSION: str = "0.2.2"
+VERSION: str = "0.2.3"


### PR DESCRIPTION
maybe a 0.2.4 should be released so that the current tag does not get republished with the fixed version